### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chaincoin-node-api",
 	"author": "Niel de la Rouviere",
 	"description": "chaincoin-node-api is an Express middleware plugin that exposes URLs for quick development and interfacing with a chaincoind chaincoin wallet.",
-  "version": "1.0.3",
+  "version": "1.0.5",
 	"main": "lib/api.js",
 	"repository" : {
 		"type": "git",


### PR DESCRIPTION
For some weird reason, I already had a 1.0.3 version published. I published, and updated here, to the 1.0.5

Like you can see, [here](https://www.npmjs.com/package/chaincoin-node-api)