### PR TITLE
Addded support for pivx based blockchains

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -28,9 +28,12 @@ module.exports = function(){
       }
 
       var command = [];
-
+      //this is an case for pivx
+      if(/^getpivx/.test(method)){
+        command = specialPivxCase(method);
+      }
       //this is pretty dirty but it is working for now
-      if(method == 'sendmany' || 
+      else if(method == 'sendmany' || 
           method == 'getmasternodecount' || 
           method == 'getmasternodecountonline' || 
           method == 'getmasternodelist' || 
@@ -126,6 +129,22 @@ module.exports = function(){
         method_name = 'masternode';
         params.push('count');
         params.push('enabled');
+      }
+
+      return [{
+        method: method_name,
+        params: params
+      }];
+    }
+
+    function specialPivxCase(method_name){
+      var params = [];
+      if(method_name == 'getpivxmasternodecount'){
+        method_name = 'getmasternodecount';
+      }
+
+      if(method_name == 'getpivxmasternodelist'){
+        method_name = 'listmasternodes';
       }
 
       return [{


### PR DESCRIPTION
PIVX has changed its masternode commands' scheme from `masternode foo` to `getmasternodefoo`. Since the methods with this new naming schemes are already being intercepted and modified, we have added a new interceptor function for PIVX's methods. Specifically, the `getpivxmasternodecount` and `getpivxmasternodelist` methods are intercepted and converted to their respective PIVX equivalent.